### PR TITLE
Prevent compiler optimization

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 
 #define BUTTON_PIN PB11
 
-unsigned flag=0;
+volatile unsigned flag=0;
 
 void button_isr() {
 if(flag)


### PR DESCRIPTION
Forces a re-read of the flag within the main code. Otherwise the logic will not always correct when using code optimization flags (`-Os`, which is the default).